### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
 # Carthage/Checkouts
 
-Carthage/Build
+Carthage
 
 # fastlane
 #


### PR DESCRIPTION
* [x] prevented `Carthage/Checkouts` from being checked in.